### PR TITLE
Rework of the output directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,6 @@ jobs:
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
 
-      - name: Run the full test profile of the pipeline (requires sanger-tol/insdcdownload)
+      - name: Run the full test profile of the pipeline
         run: |
-          mkdir ${GITHUB_WORKSPACE}/data
-          cd ${GITHUB_WORKSPACE}/data
-          nextflow run sanger-tol/insdcdownload -revision 1.1.0 -profile docker --assembly_name iOsmBic2.1 --assembly_accession GCA_907164935.1 --outdir 25g/data/insects/Osmia_bicornis
-          nextflow run sanger-tol/insdcdownload -revision 1.1.0 -profile docker --assembly_name iOsmBic2.1_alternate_haplotype --assembly_accession GCA_907164925.1 --outdir 25g/data/insects/Osmia_bicornis
-          nextflow run sanger-tol/insdcdownload -revision 1.1.0 -profile docker --assembly_name gfLaeSulp1.1 --assembly_accession GCA_927399515.1 --outdir darwin/data/fungi/Laetiporus_sulphureus
-          nextflow run ${GITHUB_WORKSPACE} -profile test_full,docker
+          nextflow run ${GITHUB_WORKSPACE} -profile test_full,docker --outdir ./results_full

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,7 +1,5 @@
-species_dir,assembly_name,fasta
-25g/data/echinoderms/Asterias_rubens,eAstRub1.3,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/902/459/465/GCA_902459465.3_eAstRub1.3/GCA_902459465.3_eAstRub1.3_genomic.fna.gz
-25g/data/insects/Osmia_bicornis,iOsmBic2.1,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/907/164/935/GCA_907164935.1_iOsmBic2.1/GCA_907164935.1_iOsmBic2.1_genomic.fna.gz
-25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/907/164/925/GCA_907164925.1_iOsmBic2.1_alternate_haplotype/GCA_907164925.1_iOsmBic2.1_alternate_haplotype_genomic.fna.gz
-darwin/data/fungi/Laetiporus_sulphureus,gfLaeSulp1.2,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/927/399/515/GCA_927399515.2_gfLaeSulp1.2/GCA_927399515.2_gfLaeSulp1.2_genomic.fna.gz
-darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/905/163/415/GCA_905163415.1_ilNocFimb1.1/GCA_905163415.1_ilNocFimb1.1_genomic.fna.gz
-darwin/data/mammals/Meles_meles,mMelMel3.2_paternal_haplotype,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/922/984/935/GCA_922984935.2_mMelMel3.2_paternal_haplotype/GCA_922984935.2_mMelMel3.2_paternal_haplotype_genomic.fna.gz
+outdir,fasta
+Asterias_rubens/eAstRub1.3,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/902/459/465/GCA_902459465.3_eAstRub1.3/GCA_902459465.3_eAstRub1.3_genomic.fna.gz
+Osmia_bicornis/iOsmBic2.1,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/907/164/935/GCA_907164935.1_iOsmBic2.1/GCA_907164935.1_iOsmBic2.1_genomic.fna.gz
+Osmia_bicornis/iOsmBic2.1_alternate_haplotype,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/907/164/925/GCA_907164925.1_iOsmBic2.1_alternate_haplotype/GCA_907164925.1_iOsmBic2.1_alternate_haplotype_genomic.fna.gz
+Noctua_fimbriata/ilNocFimb1.1,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/905/163/415/GCA_905163415.1_ilNocFimb1.1/GCA_905163415.1_ilNocFimb1.1_genomic.fna.gz

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,4 +1,7 @@
-species_dir,assembly_name
-25g/data/insects/Osmia_bicornis,iOsmBic2.1
-25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype
-darwin/data/fungi/Laetiporus_sulphureus,gfLaeSulp1.1
+species_dir,assembly_name,fasta
+25g/data/echinoderms/Asterias_rubens,eAstRub1.3,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/902/459/465/GCA_902459465.3_eAstRub1.3/GCA_902459465.3_eAstRub1.3_genomic.fna.gz
+25g/data/insects/Osmia_bicornis,iOsmBic2.1,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/907/164/935/GCA_907164935.1_iOsmBic2.1/GCA_907164935.1_iOsmBic2.1_genomic.fna.gz
+25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/907/164/925/GCA_907164925.1_iOsmBic2.1_alternate_haplotype/GCA_907164925.1_iOsmBic2.1_alternate_haplotype_genomic.fna.gz
+darwin/data/fungi/Laetiporus_sulphureus,gfLaeSulp1.2,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/927/399/515/GCA_927399515.2_gfLaeSulp1.2/GCA_927399515.2_gfLaeSulp1.2_genomic.fna.gz
+darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/905/163/415/GCA_905163415.1_ilNocFimb1.1/GCA_905163415.1_ilNocFimb1.1_genomic.fna.gz
+darwin/data/mammals/Meles_meles,mMelMel3.2_paternal_haplotype,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/922/984/935/GCA_922984935.2_mMelMel3.2_paternal_haplotype/GCA_922984935.2_mMelMel3.2_paternal_haplotype_genomic.fna.gz

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -7,27 +7,17 @@
     "items": {
         "type": "object",
         "properties": {
-            "species_dir": {
+            "outdir": {
                 "type": "string",
                 "pattern": "^\\S+$",
                 "errorMessage": "Species directory must be provided and exist"
             },
-            "assembly_name": {
-                "type": "string",
-                "pattern": "^\\S+$",
-                "errorMessage": "Assembly name must be provided and cannot contain spaces"
-            },
-            "assembly_accession": {
-                "type": "string",
-                "pattern": "^GCA_[0-9]{9}\\.[0-9]+$",
-                "errorMessage": "Assembly accession number must be provided and be of the form GCA_*"
-            },
             "fasta": {
                 "type": "string",
                 "pattern": "^\\S+$",
-                "errorMessage": "Assembly path is optional"
+                "errorMessage": "Assembly path is mandatory"
             }
         },
-        "required": ["species_dir", "assembly_name"]
+        "required": ["outdir", "fasta"]
     }
 }

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -21,6 +21,11 @@
                 "type": "string",
                 "pattern": "^GCA_[0-9]{9}\\.[0-9]+$",
                 "errorMessage": "Assembly accession number must be provided and be of the form GCA_*"
+            },
+            "fasta": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "Assembly path is optional"
             }
         },
         "required": ["species_dir", "assembly_name"]

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -79,6 +79,7 @@ class RowChecker:
         if set(row[self._fasta_col]) == set(" "):
             raise AssertionError("Paths cannot only be whitespace.")
 
+
 def read_head(handle, num_lines=10):
     """Read the specified number of lines from the current position in the file."""
     lines = []

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -31,6 +31,7 @@ class RowChecker:
         dir_col="species_dir",
         name_col="assembly_name",
         accession_col="assembly_accession",
+        fasta_col="fasta",
         **kwargs,
     ):
         """
@@ -43,12 +44,15 @@ class RowChecker:
                 (default "assembly_name").
             accession_col (str): The name of the column that contains the accession
                 number (default "assembly_accession").
+            fasta_col (str): The name of the column that contains the path to the
+                Fasta (default "fasta").
 
         """
         super().__init__(**kwargs)
         self._dir_col = dir_col
         self._name_col = name_col
         self._accession_col = accession_col
+        self._fasta_col = fasta_col
         self._seen = set()
         self.modified = []
         self._regex_accession = re.compile(r"^GCA_[0-9]{9}\.[0-9]+$")
@@ -65,6 +69,7 @@ class RowChecker:
         self._validate_dir(row)
         self._validate_name(row)
         self._validate_accession(row)
+        self._validate_fasta(row)
         self._seen.add((row[self._name_col], row[self._dir_col]))
         self.modified.append(row)
 
@@ -96,6 +101,10 @@ class RowChecker:
         if len(self._seen) != len(self.modified):
             raise AssertionError("The pair of species directories and assembly names must be unique.")
 
+    def _validate_fasta(self, row):
+        """Assert that the fasta path is not only white space."""
+        if set(row[self._fasta_col]) == set(" "):
+            raise AssertionError("Paths cannot only be whitespace.")
 
 def read_head(handle, num_lines=10):
     """Read the specified number of lines from the current position in the file."""

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -14,7 +14,7 @@ process {
 
     withName: '.*:.*:.*:TABIX_.*' {
         publishDir = [
-            path: { "${meta.analysis_dir}/${meta.analysis_subdir}" },
+            path: { "${meta.outdir}/${meta.analysis_subdir}" },
             mode: 'copy',
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,19 +64,18 @@ It has to be a comma-separated file with 2 columns, and a header row as shown in
 nextflow run sanger-tol/sequencecomposition --input '[path to samplesheet file]' --outdir <OUTDIR>
 ```
 
-The values in the file are used to make up the paths under which the Fasta files can be found,
-and the outputs be written.
+The values in the file are used to make up the `--fasta` and `--outdir` parameters.
 
 ```console
-species_dir,assembly_name
-darwin/data/fungi/Laetiporus_sulphureus,gfLaeSulp1.1
-darwin/data/mammals/Meles_meles,mMelMel3.2_paternal_haplotype
+outdir,fasta
+Laetiporus_sulphureus/gfLaeSulp1.1,/path/to/gfLaeSulp1.1.fasta
+Meles_meles/mMelMel3.2_paternal_haplotype,/path/to/mMelMel3.2_paternal_haplotype.fasta
 ```
 
-| Column          | Description                                                                                   |
-| --------------- | --------------------------------------------------------------------------------------------- |
-| `species_dir`   | Base directory of that species, which is expected to comply with the ToL directory structure. |
-| `assembly_name` | Name of the assembly, as on the NCBI website, e.g. `gfLaeSulp1.1`.                            |
+| Column   | Description                                                                                                                                     |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `outdir` | Output directory for this pipeline (evaluated from `--outdir` if a relative path). Analysis results are in a sub-directory `gene/base_content`. |
+| `fasta`  | Path to the Fasta file of this assembly (can be a remote file).                                                                                 |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
 

--- a/lib/WorkflowSequencecomposition.groovy
+++ b/lib/WorkflowSequencecomposition.groovy
@@ -23,8 +23,7 @@ class WorkflowSequencecomposition {
             }
         }
         if (!params.outdir) {
-            log.error "--outdir is mandatory"
-            System.exit(1)
+            Nextflow.error "--outdir is mandatory"
         }
     }
 

--- a/lib/WorkflowSequencecomposition.groovy
+++ b/lib/WorkflowSequencecomposition.groovy
@@ -18,9 +18,13 @@ class WorkflowSequencecomposition {
                 Nextflow.error "'${params.input}' doesn't exist"
             }
         } else {
-            if (!params.fasta || !params.outdir) {
-                Nextflow.error "Either --input, or --fasta and--outdir must be provided"
+            if (!params.fasta) {
+                Nextflow.error "Either --input or --fasta must be provided"
             }
+        }
+        if (!params.outdir) {
+            log.error "--outdir is mandatory"
+            System.exit(1)
         }
     }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -22,7 +22,8 @@
                 "outdir": {
                     "type": "string",
                     "format": "directory-path",
-                    "description": "The output directory where the results will be saved. Not considered when running the pipeline with a .csv file as input.",
+                    "description": "The output directory where the results will be saved. Not considered for sample-sheet entries that have an absolute path.",
+                    "default": "results",
                     "fa_icon": "fas fa-folder-open"
                 },
                 "selected_fw_output": {
@@ -46,7 +47,7 @@
                     "pattern": "^\\S+\\.csv$",
                     "schema": "assets/schema_input.json",
                     "description": "Path to comma-separated file containing information about the genomes to analyse. Used for bulk analysis of many genomes.",
-                    "help_text": "The file has to be a comma-separated file with two columns, and a header row. The columns names must be `species_dir` and `assembly_name`. An additional `assembly_accession` column can be provided too.",
+                    "help_text": "The file has to be a comma-separated file with two columns, and a header row. The columns names must be `outdir` and `fasta`.",
                     "fa_icon": "fas fa-file-csv"
                 },
                 "email": {

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -14,43 +14,40 @@ workflow PARAMS_CHECK {
 
 
     main:
-
     ch_versions = Channel.empty()
 
     ch_inputs = Channel.empty()
     if (samplesheet) {
-
         SAMPLESHEET_CHECK ( file(samplesheet, checkIfExists: true) )
             .csv
-            // Provides species_dir and assembly_name
+            // Provides outdir and fasta
             .splitCsv ( header:true, sep:',' )
-            .map {
-                it + [
-                    ]
-            }
-            .map { make_input_tuple(it, outdir) }
+            .map { [
+                (it["outdir"].startsWith("/") ? "" : outdir + "/") + it["outdir"],
+                it["fasta"],
+            ] }
             .set { ch_inputs }
 
         ch_versions = ch_versions.mix(SAMPLESHEET_CHECK.out.versions)
 
     } else {
+        // Add the other input channel in, as it's expected to have all the parameters in the right order
+        ch_inputs = ch_inputs.mix(cli_params.map { [outdir] + it } )
+    }
 
-        ch_inputs = cli_params.map {
-             file(it[0], checkIfExists: true)
-        } .map { file_fasta ->
+    ch_input_files = ch_inputs.map { outdir, fasta ->
+        file_fasta = file(fasta, checkIfExists: true)
+        return [
             [
-                [
-                    id: file_fasta.baseName,
-                    analysis_dir: outdir,
-                ],
-                file_fasta,
-            ]
-        }
-
+                id: file_fasta.baseName,
+                outdir: outdir,
+            ],
+            file_fasta,
+        ]
     }
 
     // Only flow to gunzip when required
-    ch_parsed_fasta_name = ch_inputs.branch {
+    ch_parsed_fasta_name = ch_input_files.branch {
         meta, filename ->
             compressed : filename.getExtension().equals('gz')
             uncompressed : true
@@ -69,40 +66,3 @@ workflow PARAMS_CHECK {
     versions    = ch_versions          // channel: versions.yml
 }
 
-
-// Generate a tuple(meta,file) as required by GUNZIP and FASTAWINDOWS
-def make_input_tuple(row, outdir) {
-
-    if (row.fasta && row.assembly_accession) {
-        Nextflow.error "Fasta and accession can't be provided at the same time"
-    }
-
-    // Add outdir to species_dir, if needed
-    def species_dir = (row.species_dir.startsWith("/") ? "" : outdir + "/") + row.species_dir
-    // Derive the analysis directory
-    def analysis_dir = "${species_dir}/analysis/${row.assembly_name}"
-
-    // If a Fasta is provided, just use it
-    if (row.fasta) {
-        return [
-            [
-                id: row.assembly_name,
-                analysis_dir: analysis_dir,
-            ],
-            file(row.fasta, checkIfExists: true),
-        ]
-
-    } else {
-        // Assembly path, following the Tree of Life directory structure
-        def assembly_path = "${species_dir}/assembly/release/${row.assembly_name}/insdc"
-        // If assembly_accession is missing, load the accession number from file, following the Tree of Life directory structure
-        def assembly_accession = row.assembly_accession ?: file("${assembly_path}/ACCESSION", checkIfExists: true).text.trim()
-        return [
-            [
-                id: assembly_accession,
-                analysis_dir: analysis_dir,
-            ],
-            file("${assembly_path}/${assembly_accession}.fa.gz", checkIfExists: true),
-        ]
-    }
-}

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -37,9 +37,11 @@ workflow PARAMS_CHECK {
 
     ch_input_files = ch_inputs.map { outdir, fasta ->
         file_fasta = file(fasta, checkIfExists: true)
+        // Trick to strip the Fasta extension for gzipped files too, without having to list all possible extensions
+        id = file(fasta.replace(".gz", "")).baseName
         return [
             [
-                id: file_fasta.baseName,
+                id: id,
                 outdir: outdir,
             ],
             file_fasta,

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -8,12 +8,12 @@ include { SAMPLESHEET_CHECK } from '../../modules/local/samplesheet_check'
 workflow PARAMS_CHECK {
 
     take:
-    inputs          // tuple, see below
+    samplesheet  // file
+    cli_params   // tuple, see below
+    outdir       // file output directory
 
 
     main:
-
-    def (samplesheet, fasta, outdir) = inputs
 
     ch_versions = Channel.empty()
 
@@ -56,8 +56,9 @@ workflow PARAMS_CHECK {
 
     } else {
 
-        file_fasta = file(fasta, checkIfExists: true)
-        ch_inputs = Channel.of(
+        ch_inputs = cli_params.map {
+             file(it[0], checkIfExists: true)
+        } .map { file_fasta ->
             [
                 [
                     id: file_fasta.baseName,
@@ -65,7 +66,7 @@ workflow PARAMS_CHECK {
                 ],
                 file_fasta,
             ]
-        )
+        }
 
     }
 

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -24,6 +24,12 @@ workflow PARAMS_CHECK {
             .csv
             // Provides species_dir and assembly_name
             .splitCsv ( header:true, sep:',' )
+            // Add outdir to species_dir, if needed
+            .map {
+                it + [
+                    species_dir: (it["species_dir"].startsWith("/") ? "" : outdir + "/") + it["species_dir"],
+                    ]
+            }
             // Add assembly_path, following the Tree of Life directory structure
             .map {
                 it + [

--- a/workflows/sequencecomposition.nf
+++ b/workflows/sequencecomposition.nf
@@ -43,11 +43,13 @@ workflow SEQUENCECOMPOSITION {
     ch_versions = Channel.empty()
 
     PARAMS_CHECK (
-        [
-            params.input,
-            params.fasta,
-            params.outdir,
-        ]
+        params.input,
+        Channel.of(
+            [
+                params.fasta,
+            ]
+        ),
+        params.outdir,
     )
     ch_versions         = ch_versions.mix(PARAMS_CHECK.out.versions)
 


### PR DESCRIPTION
As per https://jira.sanger.ac.uk/browse/TOLIT-1559 we want the output directories to be "analysis" directories rather than "species" directories.

First of all, this means that the sample-sheet now matches exactly the command-line parameters as in the four download pipelines, i.e. it accepts `outdir` and `fasta`. There is no need to pre-download assemblies and the sample-sheet can point to assemblies on the web. This means I don't need to run insdcdownload before the full test and can use a bigger sample-sheet as originally intended.

I'm using the convention that I'm already using in the sequencecomposition pipeline: each assembly has got its own `outdir` in its `meta`. So essentially, the output directories are defined as `meta.outdir` which either comes from the `outdir` column of the sample-sheet, or from the `--outdir` command-line parameter for one-off downloads.

I have also removed the mechanism to automatically find the accession number from the `ACCESSION` file when the output directory matches the ToL structure. As in the read-mapping and genome-note pipelines (and following the nf-core conventions), the `id` comes from the name of the input file itself.

<!--
# sanger-tol/sequencecomposition pull request

Many thanks for contributing to sanger-tol/sequencecomposition!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/sequencecomposition/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/sequencecomposition/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
