### PR TITLE
Tuned resources

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -26,8 +26,8 @@ process {
     withName: 'FASTAWINDOWS' {
         // 1 CPU per 1 Gbp
         cpus   = { check_max( Math.ceil(fasta.size() / 1000000000), 'cpus' ) }
-        // 250 MB per 100 Mbp
-        memory = { check_max( 250.MB * task.attempt * Math.ceil(fasta.size() / 100000000), 'memory' ) }
+        // 100 MB per 45 Mbp
+        memory = { check_max( 100.MB * task.attempt * Math.ceil(fasta.size() / 45000000), 'memory' ) }
     }
 
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {

--- a/conf/base.config
+++ b/conf/base.config
@@ -16,6 +16,12 @@ process {
     memory = { check_max( 50.MB * task.attempt, 'memory' ) }
     time   = { check_max( 30.min * task.attempt, 'time' ) }
 
+    // tabix needs pointers to the sequences in memory
+    withName: '.*:.*:FASTA_WINDOWS:TABIX_TABIX_.*' {
+        // 50 MB per 25,000 sequences
+        memory = { check_max( 50.MB * task.attempt * Math.ceil(meta.n_sequences / 25000), 'memory' ) }
+    }
+
     // fasta_windows takes more memory on larger genomes
     withName: 'FASTAWINDOWS' {
         // 1 CPU per 1 Gbp

--- a/modules.json
+++ b/modules.json
@@ -10,6 +10,11 @@
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
                         "installed_by": ["modules"]
                     },
+                    "custom/getchromsizes": {
+                        "branch": "master",
+                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "installed_by": ["modules"]
+                    },
                     "fastawindows": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
@@ -31,6 +36,9 @@
                         "installed_by": ["modules"]
                     }
                 }
+            },
+            "subworkflows": {
+                "nf-core": {}
             }
         }
     }

--- a/modules/nf-core/custom/getchromsizes/main.nf
+++ b/modules/nf-core/custom/getchromsizes/main.nf
@@ -1,0 +1,44 @@
+process CUSTOM_GETCHROMSIZES {
+    tag "$fasta"
+    label 'process_single'
+
+    conda "bioconda::samtools=1.16.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samtools:1.16.1--h6899075_1' :
+        'biocontainers/samtools:1.16.1--h6899075_1' }"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path ("*.sizes"), emit: sizes
+    tuple val(meta), path ("*.fai")  , emit: fai
+    tuple val(meta), path ("*.gzi")  , emit: gzi, optional: true
+    path  "versions.yml"             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    samtools faidx $fasta
+    cut -f 1,2 ${fasta}.fai > ${fasta}.sizes
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        getchromsizes: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch ${fasta}.fai
+    touch ${fasta}.sizes
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        getchromsizes: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/custom/getchromsizes/meta.yml
+++ b/modules/nf-core/custom/getchromsizes/meta.yml
@@ -1,0 +1,53 @@
+name: custom_getchromsizes
+description: Generates a FASTA file of chromosome sizes and a fasta index file
+keywords:
+  - fasta
+  - chromosome
+  - indexing
+tools:
+  - samtools:
+      description: Tools for dealing with SAM, BAM and CRAM files
+      homepage: http://www.htslib.org/
+      documentation: http://www.htslib.org/doc/samtools.html
+      tool_dev_url: https://github.com/samtools/samtools
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: FASTA file
+      pattern: "*.{fa,fasta,fna,fas}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - sizes:
+      type: file
+      description: File containing chromosome lengths
+      pattern: "*.{sizes}"
+  - fai:
+      type: file
+      description: FASTA index file
+      pattern: "*.{fai}"
+  - gzi:
+      type: file
+      description: Optional gzip index file for compressed inputs
+      pattern: "*.gzi"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@tamara-hodgetts"
+  - "@chris-cheshire"
+  - "@muffato"

--- a/subworkflows/local/fasta_windows.nf
+++ b/subworkflows/local/fasta_windows.nf
@@ -11,7 +11,7 @@ include { TABIX_TABIX as TABIX_TABIX_TBI   } from '../../modules/nf-core/tabix/t
 workflow FASTA_WINDOWS {
 
     take:
-    fasta               // file: /path/to/genome.fa
+    fasta_fai           // [file: /path/to/genome.fa, file: /path/to/genome.fai]
     output_selection    // file: /path/to/fasta_windows.csv
     window_size_info    // value, used to build meta.id and name files
 
@@ -20,7 +20,7 @@ workflow FASTA_WINDOWS {
     ch_versions = Channel.empty()
 
     // Run fasta_windows
-    FASTAWINDOWS ( fasta )
+    FASTAWINDOWS ( fasta_fai.map { meta, fasta, fai -> [meta, fasta] } )
     ch_versions       = ch_versions.mix(FASTAWINDOWS.out.versions.first())
 
     // Get the maximum coordinate used in the output files by scanning the mononuc file

--- a/subworkflows/local/fasta_windows.nf
+++ b/subworkflows/local/fasta_windows.nf
@@ -23,6 +23,9 @@ workflow FASTA_WINDOWS {
     FASTAWINDOWS ( fasta )
     ch_versions       = ch_versions.mix(FASTAWINDOWS.out.versions.first())
 
+    // Get the maximum coordinate used in the output files by scanning the mononuc file
+    ch_max_coord      = FASTAWINDOWS.out.mononuc.map { meta, tsv -> [ meta, get_max_coord(tsv) ] }
+
     // List of:
     // 1) the columns we want to extract as bedGraph from the frequency files,
     //    with the subdirectory name and the relevant part of the file name.
@@ -45,14 +48,15 @@ workflow FASTA_WINDOWS {
         }
         .set { ch_config }
 
-    // Make a combined channel: tuple(meta, freq_file_tsv, column_number, output_dir, filename),
-    ch_freq_bed_input = FASTAWINDOWS.out.freq.combine(ch_config.freq)
+    // Make a combined channel: tuple(meta, freq_file_tsv, column_number, output_dir, filename, max_coord),
+    ch_freq_bed_input = FASTAWINDOWS.out.freq.combine(ch_config.freq).combine(ch_max_coord, by: 0)
     ch_freq_bed       = EXTRACT_COLUMN (
         // Extend meta.id to name output files appropriately, and add meta.analysis_subdir
-        ch_freq_bed_input.map { [it[0] + [id: it[0].id + "." + it[4] + window_size_info, analysis_subdir: it[3]], it[1]] },
+        ch_freq_bed_input.map { [it[0] + [id: it[0].id + "." + it[4] + window_size_info, analysis_subdir: it[3], max_coord: it[5]], it[1]] },
         // column number
         ch_freq_bed_input.map { it[2] }
     ).bedgraph
+
     ch_versions       = ch_versions.mix(EXTRACT_COLUMN.out.versions.first())
 
     // Add meta information to the tsv files
@@ -61,20 +65,46 @@ workflow FASTA_WINDOWS {
         .mix( FASTAWINDOWS.out.dinuc   .combine(ch_config.dinuc) )
         .mix( FASTAWINDOWS.out.trinuc  .combine(ch_config.trinuc) )
         .mix( FASTAWINDOWS.out.tetranuc.combine(ch_config.tetranuc) )
-        .map { [it[0] + [id: it[0].id + "." + it[3] + window_size_info, analysis_subdir: it[2]], it[1]] }
+        .combine(ch_max_coord, by: 0)
+        .map { [it[0] + [id: it[0].id + "." + it[3] + window_size_info, analysis_subdir: it[2], max_coord: it[4]], it[1]] }
 
     // Compress the BED file
     ch_compressed_bed = TABIX_BGZIP ( ch_freq_bed.mix(ch_tsv) ).output
     ch_versions       = ch_versions.mix(TABIX_BGZIP.out.versions.first())
 
-    // Index the BED file in two formats for maximum compatibility
-    ch_indexed_bed_csi= TABIX_TABIX_CSI ( ch_compressed_bed ).csi
+    // Try indexing the BED file in two formats for maximum compatibility
+    // but each has its own limitations
+    tabix_selector      = ch_compressed_bed.branch { meta, bed ->
+        tbi_and_csi: meta.max_coord < 2**29
+        only_csi:    meta.max_coord < 2**32
+    }
+
+    // Do the indexing on the compatible bedGraph files
+    ch_indexed_bed_csi= TABIX_TABIX_CSI ( tabix_selector.tbi_and_csi.mix(tabix_selector.only_csi) ).csi
     ch_versions       = ch_versions.mix(TABIX_TABIX_CSI.out.versions.first())
-    ch_indexed_bed_tbi= TABIX_TABIX_TBI ( ch_compressed_bed ).tbi
+    ch_indexed_bed_tbi= TABIX_TABIX_TBI ( tabix_selector.tbi_and_csi ).tbi
     ch_versions       = ch_versions.mix(TABIX_TABIX_TBI.out.versions.first())
 
 
     emit:
     bedgraph = ch_compressed_bed
     versions = ch_versions.ifEmpty(null) // channel: [ versions.yml ]
+}
+
+// Inspired from https://github.com/nf-core/rnaseq/blob/3.10.1/lib/WorkflowRnaseq.groovy
+def get_max_coord(tsv_file) {
+    def max_coord = 0
+    tsv_file.withReader { reader ->
+        def line
+        // Skip the first line (header)
+        if ((line = reader.readLine()) != null) {
+            while ((line = reader.readLine()) != null) {
+                def end_coord = line.split()[2].toInteger()
+                if (end_coord > max_coord) {
+                    max_coord = end_coord
+                }
+            }
+        }
+    }
+    return max_coord
 }

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -2,8 +2,9 @@
 // Check and parse the input parameters
 //
 
-include { GUNZIP            } from '../../modules/nf-core/gunzip/main'
-include { SAMPLESHEET_CHECK } from '../../modules/local/samplesheet_check'
+include { CUSTOM_GETCHROMSIZES } from '../../modules/nf-core/custom/getchromsizes/main'
+include { GUNZIP               } from '../../modules/nf-core/gunzip/main'
+include { SAMPLESHEET_CHECK    } from '../../modules/local/samplesheet_check'
 
 workflow PARAMS_CHECK {
 
@@ -45,26 +46,66 @@ workflow PARAMS_CHECK {
                 outdir: outdir,
             ],
             file_fasta,
+            file(fasta + ".fai"),
         ]
     }
 
-    // Only flow to gunzip when required
+    // Identify the Fasta files that are compressed
     ch_parsed_fasta_name = ch_input_files.branch {
-        meta, filename ->
-            compressed : filename.getExtension().equals('gz')
+        meta, fasta, fai ->
+            compressed : fasta.getExtension().equals('gz')
             uncompressed : true
     }
 
-    // gunzip .fa.gz files
-    ch_unzipped_fasta   = GUNZIP ( ch_parsed_fasta_name.compressed ).gunzip
+    // uncompress them, with some channel manipulations to maintain the triplet (meta, fasta_fai)
+    ch_unzipped_fasta   = GUNZIP ( ch_parsed_fasta_name.compressed.map { meta, fasta_gz, fai -> [meta, fasta_gz] } ).gunzip
+                            .join(ch_parsed_fasta_name.compressed).map { meta, fasta, fasta_gz, fai -> [meta, fasta, fai] }
     ch_versions         = ch_versions.mix(GUNZIP.out.versions.first())
 
-    // Combine with preexisting .fa files
-    ch_plain_fasta      = ch_parsed_fasta_name.uncompressed.mix(ch_unzipped_fasta)
+    // Check if the faidx index is present
+    ch_parsed_fasta_name.uncompressed.mix(ch_unzipped_fasta).branch {
+        meta, fasta, fai ->
+            indexed : fai.exists()
+            notindexed : true
+    } . set { ch_inputs_checked }
 
+    // Generate Samtools index and chromosome sizes file, again with some channel manipulations
+    ch_samtools_faidx   = CUSTOM_GETCHROMSIZES (ch_inputs_checked.notindexed.map { meta, fasta, missing_fai -> [meta, fasta] }).fai
+                            .join(ch_inputs_checked.notindexed).map { meta, fai, fasta, missing_fai -> [meta, fasta, fai] }
+    ch_versions         = ch_versions.mix(CUSTOM_GETCHROMSIZES.out.versions)
+
+    // Read the .fai file, extract sequence statistics, and make an extended meta map
+    ch_fasta_fai = ch_inputs_checked.indexed.mix(ch_samtools_faidx).map {
+        meta, fasta, fai -> [meta + get_sequence_map(fai), fasta, fai]
+    }
 
     emit:
-    plain_fasta = ch_plain_fasta       // channel: [ val(meta), path/to/fasta ]
-    versions    = ch_versions          // channel: versions.yml
+    fasta_fai = ch_fasta_fai       // channel: [ val(meta), path/to/fasta, path/to/fai ]
+    versions  = ch_versions        // channel: versions.yml
 }
 
+// Read the .fai file to extract the number of sequences, the maximum and total sequence length
+// Inspired from https://github.com/nf-core/rnaseq/blob/3.10.1/lib/WorkflowRnaseq.groovy
+def get_sequence_map(fai_file) {
+    def n_sequences = 0
+    def max_length = 0
+    def total_length = 0
+    fai_file.eachLine { line ->
+        def lspl   = line.split('\t')
+        def chrom  = lspl[0]
+        def length = lspl[1].toInteger()
+        n_sequences ++
+        total_length += length
+        if (length > max_length) {
+            max_length = length
+        }
+    }
+
+    def sequence_map = [:]
+    sequence_map.n_sequences = n_sequences
+    sequence_map.total_length = total_length
+    if (n_sequences) {
+        sequence_map.max_length = max_length
+    }
+    return sequence_map
+}

--- a/workflows/sequencecomposition.nf
+++ b/workflows/sequencecomposition.nf
@@ -55,7 +55,7 @@ workflow SEQUENCECOMPOSITION {
 
     // Statistics extraction
     FASTA_WINDOWS (
-        PARAMS_CHECK.out.plain_fasta,
+        PARAMS_CHECK.out.fasta_fai,
         file(params.selected_fw_output, checkExists: true),
         params.window_size_info,
     )


### PR DESCRIPTION
This pull-request is about requesting the right memory resources for each process depending on its input size.

It works this way:

1. First extract the length properties of the Fasta file. This function (`get_sequence_map`) leverages the `.fai` file and adds key into `meta` - exactly like in the download pipelines.
2. Memory requirements in `conf/base.config` can then access `meta.n_sequences`, etc, but also the usual `fasta.size()`. 

I can now also correctly generate the `.tbi` and `.csi` indices depending on the input size.

<!--
# sanger-tol/sequencecomposition pull request

Many thanks for contributing to sanger-tol/sequencecomposition!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/sequencecomposition/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/sequencecomposition/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
