### PR TITLE
Increase time allocation for pipeline attempts

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -14,7 +14,7 @@ process {
     cpus          = 1
     // but still gradually increase the resources to allow the pipeline to self-heal
     memory        = { 50.MB * task.attempt }
-    time          = { 30.min * task.attempt }
+    time          = { 60.min * task.attempt }
 
     // tabix needs pointers to the sequences in memory
     withName: BGZIPTABIX {


### PR DESCRIPTION
For large genomes (>20 GB), this step was failing due to timeout error

<!--
# sanger-tol/sequencecomposition pull request

Many thanks for contributing to sanger-tol/sequencecomposition!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/sequencecomposition/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/sequencecomposition/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
